### PR TITLE
LC-1: Fix variables collision during term printing

### DIFF
--- a/app/Parser.hs
+++ b/app/Parser.hs
@@ -38,7 +38,7 @@ spaced :: (Token s ~ Char, Tokens s ~ [Char], MonadParsec e s m) => m a -> m [a]
 spaced p = sc *> sepEndBy1 p sc
 
 name :: (Token s ~ Char, MonadParsec e s m) => m String
-name = (:) <$> letterChar <*> many alphaNumChar
+name = (:) <$> letterChar <*> many (alphaNumChar <|> char '_')
 
 sc :: (Token s ~ Char, Tokens s ~ [Char], MonadParsec e s m) => m ()
 sc = L.space space1 (L.skipLineComment "--") (L.skipBlockComment "{-" "-}")

--- a/lambda-calculus.cabal
+++ b/lambda-calculus.cabal
@@ -27,6 +27,7 @@ library
       , utf8-string >=1.0
       , bytestring-trie >=0.2
       , containers ^>=0.6.0.1
+      , unordered-containers ^>=0.2.19.1
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/lambda-calculus.cabal
+++ b/lambda-calculus.cabal
@@ -26,7 +26,6 @@ library
       , bytestring
       , utf8-string >=1.0
       , bytestring-trie >=0.2
-      , containers ^>=0.6.0.1
       , unordered-containers ^>=0.2.19.1
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/lambda-calculus.cabal
+++ b/lambda-calculus.cabal
@@ -26,7 +26,7 @@ library
       , bytestring
       , utf8-string >=1.0
       , bytestring-trie >=0.2
-      , unordered-containers ^>=0.2.19.1
+      , unordered-containers >=0.2
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/lambda-calculus.cabal
+++ b/lambda-calculus.cabal
@@ -24,8 +24,14 @@ library
     build-depends:
         base
       , bytestring
+<<<<<<< HEAD
       , utf8-string >=1.0
       , bytestring-trie >=0.2
+=======
+      , utf8-string ^>=1.0
+      , bytestring-trie ^>=0.2
+      , containers
+>>>>>>> LC-1: Fix variables collision during term printing
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/lambda-calculus.cabal
+++ b/lambda-calculus.cabal
@@ -24,14 +24,9 @@ library
     build-depends:
         base
       , bytestring
-<<<<<<< HEAD
       , utf8-string >=1.0
       , bytestring-trie >=0.2
-=======
-      , utf8-string ^>=1.0
-      , bytestring-trie ^>=0.2
-      , containers
->>>>>>> LC-1: Fix variables collision during term printing
+      , containers ^>=0.6.0.1
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -4,11 +4,11 @@ import Control.Applicative ((<|>))
 import Data.Function (fix)
 import Data.List.NonEmpty (NonEmpty, last, unfoldr)
 import qualified Data.HashMap.Strict as Map
-import Data.HashMap.Strict (HashMap, findWithDefault, keysSet)
+import Data.HashMap.Strict (HashMap)
 import qualified Data.IntMap as IntMap
-import Data.IntMap (IntMap, size)
+import Data.IntMap (IntMap)
 import qualified Data.HashSet as Set
-import Data.HashSet (HashSet, fromList, member)
+import Data.HashSet (HashSet)
 import Data.StringTrie (StringTrie, insert, lookup)
 import Prelude hiding (last, lookup)
 
@@ -69,16 +69,16 @@ instance Show ResolveError where
 
 checkCollisionsHelper :: HashMap String Int -> Term -> HashMap String Int
 checkCollisionsHelper m (Var _ _) = m
-checkCollisionsHelper m (Abs x t) = let xs = findWithDefault 0 x m in checkCollisionsHelper (Map.insert x (xs + 1) m) t
+checkCollisionsHelper m (Abs x t) = let xs = Map.findWithDefault 0 x m in checkCollisionsHelper (Map.insert x (xs + 1) m) t
 checkCollisionsHelper m (App f x) = checkCollisionsHelper (checkCollisionsHelper m f) x
 
 checkCollisions :: Term -> HashSet String
-checkCollisions t = keysSet $ Map.filter (== 1) (checkCollisionsHelper Map.empty t)
+checkCollisions t = Map.keysSet $ Map.filter (== 1) (checkCollisionsHelper Map.empty t)
 
 printTerm :: HashSet String -> HashMap String (IntMap Int) -> Int -> Term -> String
-printTerm s m d (Var i x) = x ++ if x `member` s then "" else "_" ++ show ((m Map.! x) IntMap.! (d - i))
-printTerm s m d (Abs x t) = let xs = findWithDefault (IntMap.empty) x m 
-  in "\\" ++ (x ++ if x `member` s then "" else "_" ++ show (size xs)) ++ " -> " ++ printTerm s (Map.insert x (IntMap.insert (d + 1) (size xs) xs) m) (d + 1) t
+printTerm s m d (Var i x) = x ++ if x `Set.member` s then "" else "_" ++ show ((m Map.! x) IntMap.! (d - i))
+printTerm s m d (Abs x t) = let xs = Map.findWithDefault (IntMap.empty) x m 
+  in "\\" ++ (x ++ if x `Set.member` s then "" else "_" ++ show (IntMap.size xs)) ++ " -> " ++ printTerm s (Map.insert x (IntMap.insert (d + 1) (IntMap.size xs) xs) m) (d + 1) t
 printTerm s m d (App f x) = leftOp ++ " " ++ rightOp
   where
     leftOp = let showF = printTerm s m d f 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -3,6 +3,12 @@ module Data.Term where
 import Control.Applicative ((<|>))
 import Data.Function (fix)
 import Data.List.NonEmpty (NonEmpty, last, unfoldr)
+import qualified Data.Map as Map
+import Data.Map (Map, findWithDefault, keys)
+import qualified Data.IntMap as IntMap
+import Data.IntMap (IntMap, size)
+import qualified Data.Set as Set
+import Data.Set (Set, fromList, member)
 import Data.StringTrie (StringTrie, insert, lookup)
 import Prelude hiding (last, lookup)
 
@@ -61,14 +67,28 @@ shift = shift' 0
 instance Show ResolveError where
   show (NotInScope x) = "Variable not in scope: " ++ x
 
+checkCollisionsHelper :: Map String Int -> Term -> Map String Int
+checkCollisionsHelper m (Var _ _) = m
+checkCollisionsHelper m (Abs x t) = let xs = findWithDefault 0 x m in checkCollisionsHelper (Map.insert x (xs + 1) m) t
+checkCollisionsHelper m (App f x) = checkCollisionsHelper (checkCollisionsHelper m f) x
+
+checkCollisions :: Term -> Set String
+checkCollisions t = fromList $ keys $ Map.filter (== 1) (checkCollisionsHelper Map.empty t)
+
+printTerm :: Set String -> Map String (IntMap Int) -> Int -> Term -> String
+printTerm s m d (Var i x) = x ++ if x `member` s then "" else "_" ++ show ((m Map.! x) IntMap.! (d - i))
+printTerm s m d (Abs x t) = let xs = findWithDefault (IntMap.empty) x m 
+  in "\\" ++ (x ++ if x `member` s then "" else "_" ++ show (size xs)) ++ " -> " ++ printTerm s (Map.insert x (IntMap.insert (d + 1) (size xs) xs) m) (d + 1) t
+printTerm s m d (App f x) = leftOp ++ " " ++ rightOp
+  where
+    leftOp = let showF = printTerm s m d f 
+      in case f of
+        Abs _ _ -> "(" ++ showF ++ ")"
+        _ -> showF
+    rightOp = let showX = printTerm s m d x
+      in case x of
+        Var _ _ -> showX
+        _ -> "(" ++ showX ++ ")"
+
 instance Show Term where
-  show (Var _ x) = x
-  show (Abs x t) = "\\" ++ x ++ " -> " ++ show t
-  show (App f x) = leftOp ++ " " ++ rightOp
-    where
-      leftOp = case f of
-        Abs _ _ -> "(" ++ show f ++ ")"
-        _ -> show f
-      rightOp = case x of
-        Var _ _ -> show x
-        _ -> "(" ++ show x ++ ")"
+  show t = printTerm (checkCollisions t) Map.empty 0 t

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -3,10 +3,11 @@ module Data.Term where
 import Control.Applicative ((<|>))
 import Data.Function (fix)
 import Data.HashSet (HashSet)
-import qualified Data.HashSet as Set
-import Data.List.NonEmpty (NonEmpty, last, unfoldr)
-import Data.StringTrie (StringTrie, insert, lookup)
-import Prelude hiding (last, lookup)
+import qualified Data.HashSet as HashSet
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.StringTrie (StringTrie)
+import qualified Data.StringTrie as Trie
 
 data Term
   = Var Int String
@@ -24,22 +25,22 @@ isAbs _ = False
 newtype ResolveError = NotInScope String
 
 resolve :: StringTrie Term -> Term -> Either ResolveError Term
-resolve st (Var _ x) = case lookup x st of
+resolve st (Var _ x) = case Trie.lookup x st of
   Nothing -> Left (NotInScope x)
   Just tm -> Right tm
 resolve st (App f x) = App <$> resolve st f <*> resolve st x
 resolve st (Abs x t) =
-  Abs x <$> resolve (insert x (Var 0 x) $ fmap (shift 1) st) t
+  Abs x <$> resolve (Trie.insert x (Var 0 x) $ fmap (shift 1) st) t
 
 type SmallStep = Term -> Maybe Term
 
 type NanoStep = SmallStep -> SmallStep
 
 bigStep :: SmallStep -> Term -> Term
-bigStep step = last . stepLog step
+bigStep step = NonEmpty.last . stepLog step
 
 stepLog :: SmallStep -> Term -> NonEmpty Term
-stepLog step = unfoldr $ (,) <*> step
+stepLog step = NonEmpty.unfoldr $ (,) <*> step
 
 smallStep :: NanoStep -> SmallStep
 smallStep = fix
@@ -78,7 +79,7 @@ checkCollision s (App f x) = checkCollision s f || checkCollision s x
 
 formatVar :: HashSet String -> Int -> String -> String
 formatVar s i x
-  | x `Set.member` s = x ++ "_" ++ show i
+  | x `HashSet.member` s = x ++ "_" ++ show i
   | otherwise = x
 
 inBracesIf :: String -> Bool -> String
@@ -90,8 +91,8 @@ printTerm :: Int -> HashSet String -> Term -> String
 printTerm d s (Var i x) = formatVar s (d - i - 1) x
 printTerm d s (Abs x t) = "\\" ++ varName ++ " -> " ++ termBody
   where
-    mustInsert = not (x `Set.member` s) && checkCollision x t
-    s' = if mustInsert then Set.insert x s else s
+    mustInsert = not (x `HashSet.member` s) && checkCollision x t
+    s' = if mustInsert then HashSet.insert x s else s
     varName = formatVar s' d x
     termBody = printTerm (d + 1) s' t
 printTerm d s (App f x) = leftOp ++ " " ++ rightOp
@@ -100,4 +101,4 @@ printTerm d s (App f x) = leftOp ++ " " ++ rightOp
     rightOp = printTerm d s x `inBracesIf` not (isVar x)
 
 instance Show Term where
-  show = printTerm 0 Set.empty
+  show = printTerm 0 HashSet.empty


### PR DESCRIPTION
Add _i index to same named variables